### PR TITLE
prevent FileNotFoundError for missing folder

### DIFF
--- a/Write.py
+++ b/Write.py
@@ -3,6 +3,7 @@
 import argparse
 import time
 import datetime
+import os
 
 import Writer.Config
 import Writer.OllamaInterface
@@ -232,6 +233,7 @@ StatsString += f" - Disable Scrubbing: {Writer.Config.SCRUB_NO_SCRUB}  \n"
 
 # Save The Story To Disk
 SysLogger.Log("Saving Story To Disk", 3)
+os.makedirs("Stories", exist_ok=True)
 FName = f"Stories/Story_{Title.replace(' ', '_')}.md"
 if (Writer.Config.OPTIONAL_OUTPUT_NAME != ""):
     FName = Writer.Config.OPTIONAL_OUTPUT_NAME


### PR DESCRIPTION
The stories folder is not created which leads to an error:

`FileNotFoundError: [Errno 2] No such file or directory: "Stories/Story_Generic_Story_Name.md"`

This PR adds folder creation before storing the content in the md file. Alternatively you could create the folder manually and put a `.gitkeep` file in it.