### PR TITLE
Add utf-8 encoding to file writing

### DIFF
--- a/Write.py
+++ b/Write.py
@@ -261,7 +261,7 @@ os.makedirs("Stories", exist_ok=True)
 FName = f"Stories/Story_{Title.replace(' ', '_')}.md"
 if (Writer.Config.OPTIONAL_OUTPUT_NAME != ""):
     FName = Writer.Config.OPTIONAL_OUTPUT_NAME
-with open(FName, "w") as F:
+with open(FName, "w", encoding="utf-8") as F:
     Out = f"""
 {StatsString}
 


### PR DESCRIPTION
This is a windows only bug since it defaults to some other encoding by default
https://dev.to/methane/python-use-utf-8-mode-on-windows-212i