### PR TITLE
Disabled JSON mode for OpenRouter

### DIFF
--- a/Writer/Interface/Wrapper.py
+++ b/Writer/Interface/Wrapper.py
@@ -336,16 +336,6 @@ class Interface:
             Client.model = ProviderModel
             print(ProviderModel)
 
-            if _Format == "json":
-                # Overwrite the format to JSON
-                ModelOptions["format"] = "json"
-
-                # if temperature is not set, set it to 0 for JSON mode
-                if "temperature" not in ModelOptions:
-                    Client.temperature = 0
-                    Client.response_format = "json"
-                _Logger.Log("Using OpenRouter JSON Format", 4)
-
             Response = Client.chat(messages=_Messages, seed=Seed)
             _Messages.append({"role": "assistant", "content": Response})
 


### PR DESCRIPTION
Turns out it's a json map and not a boolean.
Since not every provider support `response_format` this issue would happen at random.