### PR TITLE
Fix Ollama URL parser dropping path for namespaced models

### DIFF
--- a/Writer/Interface/Wrapper.py
+++ b/Writer/Interface/Wrapper.py
@@ -496,7 +496,7 @@ class Interface:
                     Model = parsed.netloc + parsed.path.split("@")[0]
                     Host = parsed.path.split("@")[1]
                 else:
-                    Model = parsed.netloc
+                    Model = parsed.netloc + parsed.path
                     Host = "localhost:11434"
 
             else:


### PR DESCRIPTION
Fixes #85.

## Summary

One-line fix in `Writer/Interface/Wrapper.py`. The no-`@`-host branch of the Ollama URL parser was using only `parsed.netloc` and ignoring `parsed.path`, which silently broke every namespaced Ollama model (`ollama://user/model`).

## Before

```python
else:
    Model = parsed.netloc                       # drops "/model"
    Host = "localhost:11434"
```

## After

```python
else:
    Model = parsed.netloc + parsed.path         # matches the @-host branch above
    Host = "localhost:11434"
```

## Why

For `ollama://datacrystals/midnight-miqu103b-v1` (this project's own author-published 64GB+ recommendation), `urlparse` produces `netloc="datacrystals"` and `path="/midnight-miqu103b-v1"`. The old code passed only `"datacrystals"` to the Ollama API and the lookup failed with `model not found (status code: 404)`.

The same `netloc + path` concatenation pattern is already used in the sibling `@`-host Ollama branch (a few lines above) and in the openrouter branch — this change just makes the no-`@`-host case consistent with the rest.

## Verification

Tested locally with `ollama://datacrystals/midnight-miqu103b-v1`:

- **Before**: `ollama._types.ResponseError: model 'datacrystals' not found`
- **After**: model loads and runs the full pipeline without modification.

## Scope

Single line. No new behavior, no behavior change for users currently using non-namespaced or `@`-host URLs.