### PR TITLE
Open main log file with UTF-8 encoding (completes #68)

### DIFF
--- a/Writer/PrintUtils.py
+++ b/Writer/PrintUtils.py
@@ -22,7 +22,7 @@ class Logger:
         # Setup Log Path
         self.LogDirPrefix = LogDirPath
         self.LogPath = LogDirPath + "/Main.log"
-        self.File = open(self.LogPath, "a")
+        self.File = open(self.LogPath, "a", encoding='utf-8')
         self.LangchainID = 0
 
         self.LogItems = []


### PR DESCRIPTION
Completes #68.

## Summary

The three `open()` calls cited in #68 (in `SaveLangchain` and `SaveStory`) have since been updated to `encoding='utf-8'`. However, the **main log file** opened in `Logger.__init__` at line 22 was missed:

```python
self.File = open(self.LogPath, "a")    # default encoding = cp1252 on Windows
```

`self.File.write(LogEntry + "\n")` is called on every `Log()` invocation, and `LogEntry` frequently contains characters that don't round-trip through cp1252:

- Smart quotes from model output
- Em dashes (U+2014)
- Latin diacritics (in prompts, names, ancient-history content)
- Non-Latin alphabets (Cyrillic, CJK, Arabic from translation runs)
- Italian/French/German typography from `gemini` and translation flows

The result on Windows is a `UnicodeEncodeError: 'charmap' codec can't encode character ...` mid-run, with the log file partially written and the pipeline aborted.

## Fix

One-line change to add `encoding='utf-8'` to the only remaining unprotected `open()` in `Writer/PrintUtils.py`:

```python
self.File = open(self.LogPath, "a", encoding='utf-8')
```

## Verification

Tested by adding a log line containing U+2014, U+2018/2019, "Ateporix" with the *italic* Markdown delimiters, and a Cyrillic test string. Before the change: crash on Windows. After: clean append, file readable with mojibake-free content.

## Scope

Single character-encoding fix. No behavior change for users on macOS/Linux (where the platform default is already UTF-8 in modern Python).