### PR TITLE
Add dynamic per-stage `?think=true|false` for Ollama reasoning models

### DIFF
--- a/Writer/Interface/Wrapper.py
+++ b/Writer/Interface/Wrapper.py
@@ -266,6 +266,13 @@ class Interface:
             ]
             ModelOptions = ModelOptions if ModelOptions is not None else {}
 
+            # Extract chat-level kwargs (separate from Ollama model options).
+            # `think` is a chat API parameter, not a model option, so it must
+            # not appear in the `options=` dict or the ValidParameters check.
+            ChatExtras = {}
+            if "think" in ModelOptions:
+                ChatExtras["think"] = bool(ModelOptions.pop("think"))
+
             # Check if the parameters are valid
             for key in ModelOptions:
                 if key not in ValidParameters:
@@ -276,6 +283,8 @@ class Interface:
                 ModelOptions["num_ctx"] = Writer.Config.OLLAMA_CTX
 
             _Logger.Log(f"Using Ollama Model Options: {ModelOptions}", 4)
+            if ChatExtras:
+                _Logger.Log(f"Using Ollama Chat Extras: {ChatExtras}", 4)
 
             if _Format == "json":
                 # Overwrite the format to JSON
@@ -291,6 +300,7 @@ class Interface:
                 messages=_Messages,
                 stream=True,
                 options=ModelOptions,
+                **ChatExtras,
             )
             MaxRetries = 3
 
@@ -505,9 +515,20 @@ class Interface:
             Model = unquote(Model)
             QueryParams = parse_qs(parsed.query)
 
-            # Flatten QueryParams
+            # Coerce query params: bool -> float -> raw string.
+            # Strictly more permissive than the previous float-only cast;
+            # any URL that worked before still works.
             for key in QueryParams:
-                QueryParams[key] = float(QueryParams[key][0])
+                raw = QueryParams[key][0]
+                if raw.lower() == 'true':
+                    QueryParams[key] = True
+                elif raw.lower() == 'false':
+                    QueryParams[key] = False
+                else:
+                    try:
+                        QueryParams[key] = float(raw)
+                    except ValueError:
+                        QueryParams[key] = raw
 
             return Provider, Model, Host, QueryParams
         else:


### PR DESCRIPTION
Resolves #88.

## Summary

Lets users opt thinking on or off per model URL — `ollama://qwen3.5:122b-a10b?think=false` for prose generation, `ollama://gpt-oss:120b?think=true` for the critic role. Behavior with no `?think=` is identical to current `main`.

Two small changes in `Writer/Interface/Wrapper.py`, no other files touched.

## Why

The framework already strips `<think>...</think>` post-hoc via `RemoveThinkTagFromAssistantMessages`. That cleanup is correct but pays the generation cost (latency, output tokens) even on calls where thinking adds no value — scene-by-scene chapter writing, character pass, dialogue pass. Conversely, the structured-judgment calls (`LLMSummaryCheck`, `GetFeedbackOnChapter`, `GetChapterRating`) get measurably better calibration when thinking is on. A per-stage toggle catches both gains.

This rides on the existing URL-as-config mechanism — no new `Config.py` constants, no breaking change, and the 13 model knobs already in `Config.py` automatically inherit the new affordance.

## What

### 1. Query parameter parser now handles booleans (and strings)

The previous parser hard-cast every value through `float()`, which is why `?think=false` raised `ValueError` before it ever reached the chat call. New coercion: `bool → float → raw string`. Strictly more permissive — every URL that worked before still works.

```python
for key in QueryParams:
    raw = QueryParams[key][0]
    if raw.lower() == 'true':
        QueryParams[key] = True
    elif raw.lower() == 'false':
        QueryParams[key] = False
    else:
        try:
            QueryParams[key] = float(raw)
        except ValueError:
            QueryParams[key] = raw
```

### 2. `think` is popped from `ModelOptions` and passed as a chat-level kwarg

`think` is **not** in Ollama's model-parameter list — it's a chat API parameter on the Python client. So it has to live outside `options=` and outside the `ValidParameters` allowlist:

```python
# Extract chat-level kwargs (separate from Ollama model options).
# `think` is a chat API parameter, not a model option, so it must
# not appear in the `options=` dict or the ValidParameters check.
ChatExtras = {}
if "think" in ModelOptions:
    ChatExtras["think"] = bool(ModelOptions.pop("think"))

# ... existing ValidParameters check / num_ctx default / JSON-mode ...

Stream = self.Clients[_Model].chat(
    model=ProviderModel,
    messages=_Messages,
    stream=True,
    options=ModelOptions,
    **ChatExtras,
)
```

A new log line — `Using Ollama Chat Extras: {'think': False}` — fires only when an extra is set, so it stays out of the way for users not using the feature.

## Verification

Tested with `qwen3.5:122b-a10b` on a real chapter-generation pipeline:

| URL | `<think>` blocks in output | Notes |
|---|---|---|
| `ollama://qwen3.5:122b-a10b` (no param) | yes | Current behavior preserved |
| `ollama://qwen3.5:122b-a10b?think=false` | none | Confirmed via debug log; output is pure prose |
| `ollama://qwen3.5:122b-a10b?think=true` | yes | Forced thinking even on tasks where Qwen would otherwise auto-suppress |

For `?think=false` on a 1660-token generation at 196k context: same generation time, same output quality, no `<think>` blocks polluting the pre-strip text.

## Compatibility

- **No `?think=`**: behavior unchanged. Zero impact on existing users.
- **`requirements.txt`**: needs `ollama` Python client ≥ 0.4 (the version that introduced the `think` kwarg). Currently unpinned at `ollama`, so latest stable picks this up automatically.
- **Non-Ollama providers**: untouched. The parser upgrade runs before the provider branch but is strictly more permissive than the old parser.

## Scope

~20 lines net added (one new parser block, one new pop-and-pass block, one new log line). No refactors, no new files, no new dependencies, no `Config.py` changes.